### PR TITLE
Fix NumPy 2.x runtime compatibility

### DIFF
--- a/goodpoints/ctt.py
+++ b/goodpoints/ctt.py
@@ -81,23 +81,23 @@ def ctt(X1,X2,g,B=39,s=16,lam=1.,kernel="gauss",null_seed=None,
     # Prepare integer random number generator seeds for each dataset
     stat_rng = np.random.default_rng(statistic_seed)
     stat_ss = stat_rng.bit_generator._seed_seq.spawn(2)
-    stat_seed1 = stat_ss[0].generate_state(1)
-    stat_seed2 = stat_ss[1].generate_state(1)
-        
+    stat_seed1 = int(stat_ss[0].generate_state(1)[0])
+    stat_seed2 = int(stat_ss[1].generate_state(1)[0])
+
     # Identify coreset for each compression bin
     kernel_type = b"gaussian"
     hatX1_indices = compress.compress_kt(
-        X1, kernel_type, k_params = lam_sqd, g = g, num_bins = num_bins1, 
+        X1, kernel_type, k_params = lam_sqd, g = g, num_bins = num_bins1,
         delta = delta, seed = stat_seed1)
     hatX2_indices = compress.compress_kt(
-        X2, kernel_type, k_params = lam_sqd, g = g, num_bins = num_bins2, 
+        X2, kernel_type, k_params = lam_sqd, g = g, num_bins = num_bins2,
         delta = delta, seed = stat_seed2)
 
     # Compute sum of Gaussian kernel evaluations between each pair
     # of coresets
     avg_matrix = np.empty((num_bins_total,num_bins_total))
     gaussianc.sum_gaussian_kernel_by_bin(X1[hatX1_indices], X2[hatX2_indices],
-                                         lam_sqd, avg_matrix)
+                                         lam**2, avg_matrix)
     # Normalize each sum by the number of kernel evaluations
     avg_matrix /= (bin_size**2)
 
@@ -376,8 +376,8 @@ def lrctt(X1,X2,g,r,B=39,a=0,s=16,lam=1.,use_permutations=False,
     # Prepare integer random number generator seeds for each dataset
     stat_rng = np.random.default_rng(statistic_seed)
     stat_ss = stat_rng.bit_generator._seed_seq.spawn(2)
-    stat_seed1 = stat_ss[0].generate_state(1)
-    stat_seed2 = stat_ss[1].generate_state(1)
+    stat_seed1 = int(stat_ss[0].generate_state(1)[0])
+    stat_seed2 = int(stat_ss[1].generate_state(1)[0])
 
     # Identify coreset for each compression bin
     if out_thresh1 == n1:
@@ -386,8 +386,8 @@ def lrctt(X1,X2,g,r,B=39,a=0,s=16,lam=1.,use_permutations=False,
     else:
         kernel_type = b"gaussian"
         hatX1_indices = compress.compress_kt(
-            X1, kernel_type, g = g, num_bins = comp_bins1, 
-            k_params = lam_sqd, delta = delta, 
+            X1, kernel_type, g = g, num_bins = comp_bins1,
+            k_params = lam_sqd, delta = delta,
             seed = stat_seed1)
         hatX1 = X1[hatX1_indices]
     if out_thresh2 == n2:
@@ -533,11 +533,11 @@ def actt(X1,X2,g,B=299,B_2=200,B_3=20,s=16,lam=np.array([1.]),weights=np.array([
     if same_compression:
         # For all bandwidths jointly, identify coreset for each compression bin
         hatX1_indices = compress.compress_kt(
-            X1, kernel_type, g = g, num_bins = num_bins1, k_params = lam_sqd, 
-            delta = delta, seed = stat_ss[0].generate_state(1))
+            X1, kernel_type, g = g, num_bins = num_bins1, k_params = lam_sqd,
+            delta = delta, seed = int(stat_ss[0].generate_state(1)[0]))
         hatX2_indices = compress.compress_kt(
-            X2, kernel_type, g = g, num_bins = num_bins2, k_params = lam_sqd, 
-            delta = delta, seed = stat_ss[1].generate_state(1))
+            X2, kernel_type, g = g, num_bins = num_bins2, k_params = lam_sqd,
+            delta = delta, seed = int(stat_ss[1].generate_state(1)[0]))
 
         # For each bandwidth, compute sum of Gaussian kernel evaluations
         # between each pair of coresets
@@ -548,13 +548,13 @@ def actt(X1,X2,g,B=299,B_2=200,B_3=20,s=16,lam=np.array([1.]),weights=np.array([
         for k, bw in enumerate(lam):
             # Identify coreset for each compression bin
             hatX1_indices = compress.compress_kt(
-                X1, kernel_type, g = g, num_bins = num_bins1, 
-                k_params = lam_sqd[k:k+1], 
-                delta = delta, seed = stat_ss[2*k].generate_state(1))
+                X1, kernel_type, g = g, num_bins = num_bins1,
+                k_params = lam_sqd[k:k+1],
+                delta = delta, seed = int(stat_ss[2*k].generate_state(1)[0]))
             hatX2_indices = compress.compress_kt(
-                X2, kernel_type, g = g, num_bins = num_bins2, 
-                k_params = lam_sqd[k:k+1], 
-                delta = delta, seed = stat_ss[2*k+1].generate_state(1))
+                X2, kernel_type, g = g, num_bins = num_bins2,
+                k_params = lam_sqd[k:k+1],
+                delta = delta, seed = int(stat_ss[2*k+1].generate_state(1)[0]))
 
             # Compute sum of Gaussian kernel evaluations
             # between each pair of coresets

--- a/goodpoints/ctt.py
+++ b/goodpoints/ctt.py
@@ -66,7 +66,8 @@ def ctt(X1,X2,g,B=39,s=16,lam=1.,kernel="gauss",null_seed=None,
         raise ValueError(f"Unsupported kernel name {kernel}")
     
     # Store squared bandwidth in an array
-    lam_sqd = np.array([lam**2])
+    lam_sqd_scalar = lam**2
+    lam_sqd = np.array([lam_sqd_scalar])
     
     # Number of sample poins
     n1 = X1.shape[0]
@@ -97,7 +98,7 @@ def ctt(X1,X2,g,B=39,s=16,lam=1.,kernel="gauss",null_seed=None,
     # of coresets
     avg_matrix = np.empty((num_bins_total,num_bins_total))
     gaussianc.sum_gaussian_kernel_by_bin(X1[hatX1_indices], X2[hatX2_indices],
-                                         lam**2, avg_matrix)
+                                         lam_sqd_scalar, avg_matrix)
     # Normalize each sum by the number of kernel evaluations
     avg_matrix /= (bin_size**2)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy", "Cython"]
+requires = ["setuptools", "wheel", "numpy>=2.0", "Cython"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
-from setuptools import setup, find_packages
-from distutils.extension import Extension
+from setuptools import setup, find_packages, Extension
 from Cython.Build import cythonize
 from os.path import join, dirname
 import numpy


### PR DESCRIPTION
## Summary

The `goodpoints` package fails at runtime under NumPy 2.x when calling `ctt()`, `lrctt()`, or `actt()`. The `rff()` function is unaffected.

**Root cause:** NumPy 2.0 [tightened implicit scalar conversion](https://numpy.org/doc/stable/numpy_2_0_migration_guide.html) — 1-element arrays no longer implicitly convert to scalars at Cython `cpdef` boundaries. This causes `TypeError: only 0-dimensional arrays can be converted to Python scalars` when seed values (produced by `SeedSequence.generate_state(1)`, which returns a 1-element `uint32` array) are passed to Cython functions expecting `const long`.

A secondary instance of the same issue: `sum_gaussian_kernel_by_bin()` expects `const double lam_sqd` but receives `np.array([lam**2])` (a 1-element array).

**What does NOT need fixing:** The Cython C API (`bitgen_t`, `random_standard_uniform`, `npyrandom`/`npymath` linking) is fully stable and ABI-compatible through NumPy 2.4. The build system works correctly — only the Python wrapper code needed changes.

## Changes

### `goodpoints/ctt.py` (7 locations across 3 functions)

- **`ctt()`**: Convert `generate_state(1)` → `int(generate_state(1)[0])` for seed arguments (2 locations), and pass `lam**2` (scalar) instead of `lam_sqd` (1-element array) to `sum_gaussian_kernel_by_bin()` (1 location)
- **`lrctt()`**: Same seed fix (2 locations)
- **`actt()`**: Same seed fix applied inline (4 locations)

### `setup.py`

- Replace deprecated `from distutils.extension import Extension` with `from setuptools import Extension`. The `distutils` module was removed in Python 3.12; setuptools currently shims it but the shim is deprecated.

### `pyproject.toml`

- Pin build dependency to `numpy>=2.0`. Per [NumPy's guidance](https://numpy.org/doc/stable/dev/depending_on_numpy.html), wheels built against NumPy 2.x are backward-compatible with NumPy 1.x at runtime, but not vice versa. Since PEP 517 isolated builds use a separate environment, this does not affect the user's runtime NumPy version.
- Fix missing trailing newline.

## Verification

Tested against **NumPy 2.4.4 + Python 3.14.5** (macOS ARM64):

1. All 5 Cython extensions compile and link successfully
2. All modules import without error
3. All four public functions verified end-to-end:
   - `ctt.rff()` ✅
   - `ctt.ctt()` ✅
   - `ctt.lrctt()` ✅
   - `ctt.actt()` ✅

## Error trace (before fix)

```
ctt.ctt(X, Y, g=4)
  → compress.compress_kt(..., seed=stat_seed1)    # stat_seed1 is np.array([...], dtype=uint32)
    → compressc.compress(..., const long halve_seed, ...)
TypeError: only 0-dimensional arrays can be converted to Python scalars
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>