### PR TITLE
Fix NumPy 2.x scalar compat in split_X and off-by-one in rejects

### DIFF
--- a/goodpoints/ctt.py
+++ b/goodpoints/ctt.py
@@ -656,7 +656,7 @@ class TestResults:
             num_greater = (self.estimator_values[thresh_index+1:] > 
                            self.threshold_values).sum()
             # Count the number of values < threshold
-            num_less = (self.estimator_values[:thresh_index-1] < 
+            num_less = (self.estimator_values[:thresh_index] <
                          self.threshold_values).sum()
             # Reject a particular fraction of the time to ensure test has level alpha
             self.rejects = (B_plus_1*alpha - num_greater)/(
@@ -857,7 +857,7 @@ class AggregatedTestResults:
             num_greater = (est_vals[thresh_index+1:] >
                            thresh_val).sum()
             # Count the number of values < threshold
-            num_less = (est_vals[:thresh_index-1] <
+            num_less = (est_vals[:thresh_index] <
                         thresh_val).sum()
             # Reject a particular fraction of the time to ensure test has level alpha
             self.rejects_median = (B_plus_1*self.alpha - num_greater)/(

--- a/goodpoints/kt.py
+++ b/goodpoints/kt.py
@@ -317,14 +317,15 @@ def split_X(X, m, kernel, delta=0.5, seed=None, verbose=False):
                 # Number of points in parent_coreset
                 parent_idx = (i+1) // num_parent_coresets
                 # Get last two points from the parent coreset
+                point1, point2 = parent_coreset[parent_idx-2], parent_coreset[parent_idx-1]
                 # newaxis ensures array dimensions are appropriate for kernel function
-                point1, point2 = parent_coreset[parent_idx-2, newaxis], parent_coreset[parent_idx-1, newaxis]
+                point1_arr, point2_arr = point1[newaxis], point2[newaxis]
                 # Compute kernel(x1, x2)
-                K12 = k(point1,point2)
+                K12 = np.asarray(k(point1_arr, point2_arr)).item()
 
                 # Use adaptive failure threshold
                 # Compute b^2 = ||f||^2 = ||k(x1,.) - k(x2,.)||_k^2
-                b_sqd = diagK[point2] + diagK[point1] - 2*K12
+                b_sqd = float(diagK[point2] + diagK[point1] - 2*K12)
                 # Update threshold for halving parent coreset
                 # a = max(b sig sqrt(j_log_multiplier), b^2)
                 thresh = max(np.sqrt(sig_sqd[j][j2]*b_sqd*j_log_multiplier), b_sqd)
@@ -358,8 +359,8 @@ def split_X(X, m, kernel, delta=0.5, seed=None, verbose=False):
                     # Subtract 2 * inner product with all points in left child coreset:
                     # - 2 * sum_{l < child_idx} <k(coreset[j][l],.), k(x1, .) - k(x2, .)> 
                     child_points = left_child_coreset[:child_idx]
-                    point1_kernel_sum = np.sum(k(point1,child_points))
-                    point2_kernel_sum = np.sum(k(point2,child_points))
+                    point1_kernel_sum = np.sum(k(point1_arr,child_points))
+                    point2_kernel_sum = np.sum(k(point2_arr,child_points))
                     alpha -= 2*(point1_kernel_sum - point2_kernel_sum)
                 else:
                     point1_kernel_sum = 0


### PR DESCRIPTION
## Summary

Fixes two bugs discovered while building a comprehensive test suite for the package.

### Bug 1: NumPy 2.x compatibility in `split_X` (`kt.py`)

**Problem:** In `split_X`, `point1` and `point2` are created as 1-element arrays via `newaxis` (line 321). This causes:
- `k(point1, point2)` to return a 1-element array instead of a scalar
- `diagK[point2] + diagK[point1]` to return an array via fancy indexing
- `sig_sqd[j][j2] = b_sqd` to fail under NumPy 2.x, which no longer silently converts arrays to scalars at assignment boundaries
- `left_child_coreset[child_idx] = point1` to fail for the same reason

**Fix:** Extract `point1`/`point2` as scalars (plain integer indexing), and create separate `point1_arr`/`point2_arr` with `newaxis` only for kernel calls that need 2D input. Convert `K12` and `b_sqd` to Python scalars explicitly.

### Bug 2: Off-by-one in `num_less` calculation (`ctt.py`)

**Problem:** In `TestResults.__init__` (line 659) and `AggregatedTestResults.set_reject_median` (line 860), `num_less` is computed using `[:thresh_index-1]`. This is an off-by-one error.

After `np.partition(arr, k)`:
- `arr[k]` holds the value that would be at position `k` in sorted order
- `arr[:k]` (indices `0..k-1`) contains all elements ≤ `arr[k]`
- `arr[k+1:]` contains all elements ≥ `arr[k]`

The code counts `num_greater` (strictly > threshold) from `arr[thresh_index+1:]` — correct, since all elements ≥ threshold live there.

For `num_less`, the code should search `arr[:thresh_index]` — all elements guaranteed ≤ threshold — and filter for `< threshold`. The original `[:thresh_index-1]` excludes the element at index `thresh_index-1`, which could be strictly less than the threshold and should be counted.

Additionally, when `thresh_index == 0` (possible when `alpha >= B/(B+1)`), `[:thresh_index-1]` becomes `[:-1]`, which is nearly the entire array instead of empty.

**Fix:** `[:thresh_index-1]` → `[:thresh_index]` in both locations.

## Test plan

- [x] Verify `split_X`-based functions (`thin`, `thin_X`, `split_X`) work with `m >= 1`
- [x] Verify `actt` rejection behavior is unchanged for same-distribution and shifted-distribution cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)